### PR TITLE
Fix shebang to be installable

### DIFF
--- a/bin/pause-cleanup
+++ b/bin/pause-cleanup
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl 
+#!/usr/bin/perl 
 # PODNAME: pause-cleanup
 
 use App::PAUSE::cleanup;


### PR DESCRIPTION
`#!/usr/bin/env perl` will not be rewritten on installation, and must be so that it's run with the Perl where its prerequisites were installed. See https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/58